### PR TITLE
Cambiato filtraEventi da @GetMapping a @PostMapping, aggiunto findAllByIsCancellatoFalse.

### DIFF
--- a/src/main/java/it/dedagroup/venditabiglietti/controller/EventoController.java
+++ b/src/main/java/it/dedagroup/venditabiglietti/controller/EventoController.java
@@ -159,8 +159,14 @@ public class EventoController {
         return ResponseEntity.status(HttpStatus.OK).body(eventoService.findAllByDataOnwards(data));
     }
 
-    @GetMapping("/filtraEventi")
+    @PostMapping("/filtraEventi")
     public ResponseEntity<List<Evento>> filtraEventi(@RequestBody FiltraEventoDTORequest request){
         return ResponseEntity.status(HttpStatus.OK).body(eventoService.filtraEventi(request));
     }
+
+    @GetMapping("/tuttiGliEventi")
+    public ResponseEntity<List<Evento>> trovaTuttiGliEventi(){
+        return ResponseEntity.status(HttpStatus.OK).body(eventoService.findAllByIsCancellatoFalse());
+    }
+
 }

--- a/src/main/java/it/dedagroup/venditabiglietti/repository/EventoRepository.java
+++ b/src/main/java/it/dedagroup/venditabiglietti/repository/EventoRepository.java
@@ -26,5 +26,5 @@ public interface EventoRepository extends JpaRepository<Evento, Long> {
 
     @Query("SELECT e FROM Evento e WHERE e.data >= :data AND e.isCancellato = false ORDER BY e.data, e.ora")
     List<Evento> findAllByDataOnwards(@Param("data") LocalDate data);
-
+    List<Evento> findAllByIsCancellatoFalse();
 }

--- a/src/main/java/it/dedagroup/venditabiglietti/service/def/EventoService.java
+++ b/src/main/java/it/dedagroup/venditabiglietti/service/def/EventoService.java
@@ -34,5 +34,6 @@ public interface EventoService {
     List<Evento> findAllByDataOnwards(LocalDate data);
 
     List<Evento> filtraEventi(FiltraEventoDTORequest request);
+    List<Evento> findAllByIsCancellatoFalse();
 
 }

--- a/src/main/java/it/dedagroup/venditabiglietti/service/impl/EventoServiceImpl.java
+++ b/src/main/java/it/dedagroup/venditabiglietti/service/impl/EventoServiceImpl.java
@@ -280,4 +280,13 @@ public class EventoServiceImpl implements EventoService {
         return criteriaEventoRepository.filtraEventi(request);
     }
 
+    @Override
+    public List<Evento> findAllByIsCancellatoFalse() {
+        List<Evento> eventi = evRepo.findAllByIsCancellatoFalse();
+        if(eventi.isEmpty()){
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "Nessun evento esistente.");
+        }
+        return eventi;
+    }
+
 }


### PR DESCRIPTION
Cambiato filtraEventi da @GetMapping a @PostMapping, altrimenti dava errori nella criteria completa del principale, aggiunto findAllByIsCancellatoFalse in repository e service, più relativo endpoint.